### PR TITLE
[FIX] Compile error with std::exception on linux

### DIFF
--- a/Src/001_Encoder/SymCipherFunction.cpp
+++ b/Src/001_Encoder/SymCipherFunction.cpp
@@ -129,7 +129,7 @@ namespace core
 			case SYM_CIPHER_TYPE_AES192:	pAlgorithm = new CSymAES192();	break;
 			case SYM_CIPHER_TYPE_AES256:	pAlgorithm = new CSymAES256();	break;
 			default:
-				throw std::exception("Invalid algorithm type.");
+				throw std::runtime_error("Invalid algorithm type.");
 			}
 
 			switch(stCipherKey.nMode)
@@ -142,7 +142,7 @@ namespace core
 			case SYM_CIPHER_MODE_OFB:	pMode = new CSymModeOFB();	break;
 			case SYM_CIPHER_MODE_CTR:	pMode = new CSymModeCTR();	break;
 			default:
-				throw std::exception("Invalid cipher mode.");
+				throw std::runtime_error("Invalid cipher mode.");
 			}
 
 			if( CIPHER_METHOD_ENCRYPT == nMethod )
@@ -152,11 +152,11 @@ namespace core
 				pCipher = new CSymDecoder(pAlgorithm, pMode);
 
 			if( NULL == pCipher )
-				throw std::exception("Invalid cipher type.");
+				throw std::runtime_error("Invalid cipher type.");
 
 			pCipher->Init(stCipherKey);
 		}
-		catch (std::exception& e)
+		catch (std::runtime_error& e)
 		{
 			printf("%s\n", e.what());
 			if( pCipher )


### PR DESCRIPTION
Replace std::runtime_error from std::exception in SymCipherFunction.cpp